### PR TITLE
Added custom severity option to an alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ More documentation is available [here](https://developer.pagerduty.com/docs/even
 
 **Optional:** a custom summary for your PagerDuty alert
 
+`incident-severity`
+
+**Optional:** the severity of the incident
+
 `incident-region`
 
 **Optional:** the region where the incident occurred

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   pagerduty-dedup-key:
     description: 'The key used to correlate PagerDuty triggers, acknowledges, and resolves for the same alert.'
     required: false
+  incident-severity:
+    description: 'The severity of the incident occured'
+    required: false  
   incident-summary:
     description: 'A custom summary for your PagerDuty alert'
     required: false

--- a/index.js
+++ b/index.js
@@ -37,6 +37,11 @@ async function sendAlert(alert) {
       event_action: 'trigger',
     };
 
+    const customSeverity = core.getInput('incident-severity');
+    if (customSeverity != '') {
+      alert.payload.severity = customSeverity;
+    }
+
     const customSummary = core.getInput('incident-summary');
     if (customSummary != '') {
       alert.payload.summary = customSummary;


### PR DESCRIPTION
Added an option to allow the user to add a custom `incident-severity` option so it is no longer forced to be `critical`