### PR TITLE
Use Node v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: 'The environment where the incident occurred'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'
 branding:
   icon: 'alert-triangle'


### PR DESCRIPTION
Use Node v20 to resolve warning from Github
> cleanup / Stale Branch Cleanup
> The following actions uses Node.js version which is deprecated and will be forced to run on node20: miparnisari/action-pagerduty-alert@0.3.2. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/